### PR TITLE
Decrease Python min version; Add Python logging level specification

### DIFF
--- a/krausening-python/pyproject.toml
+++ b/krausening-python/pyproject.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/TechnologyBrewery/krausening"
 keywords = ["properties", "configuration-management"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
-javaproperties = ">=0.8.1"
+python = ">=3.8"
+javaproperties = [{version = ">=0.8.1", python = ">=3.8,<4.0"}]
 cryptography = ">=42.0.0"
 watchdog = ">=2.1.9"
 

--- a/krausening-python/src/krausening/logging/log_manager.py
+++ b/krausening-python/src/krausening/logging/log_manager.py
@@ -5,6 +5,16 @@ class LogManager:
     """
     Class for handling logging.
     """
+    DEFAULT_LOG_LEVEL = 'INFO'
+
+    LOG_LEVELS = {
+    'CRITICAL': logging.CRITICAL,
+    'ERROR': logging.ERROR,
+    'WARNING': logging.WARNING,
+    'INFO': logging.INFO,
+    'DEBUG': logging.DEBUG,
+    'NOTSET': logging.NOTSET,
+}
 
     __instance = None
 
@@ -26,9 +36,14 @@ class LogManager:
         else:
             LogManager.__instance = self
 
-    def get_logger(self, name: str) -> logging.Logger:
+    def _get_log_level(self, log_level: str) -> int:
+        return self.LOG_LEVELS.get(log_level, self.LOG_LEVELS[self.DEFAULT_LOG_LEVEL])
+
+    def get_logger(self, name: str, log_level: str = DEFAULT_LOG_LEVEL) -> logging.Logger:
         logger = logging.getLogger(name)
         logger.addHandler(LogManager.__handler)
-        logger.setLevel(logging.INFO)
+
+        log_level = self._get_log_level(log_level)
+        logger.setLevel(log_level)
 
         return logger

--- a/krausening-python/tests/features/logging.feature
+++ b/krausening-python/tests/features/logging.feature
@@ -1,0 +1,29 @@
+@logging
+Feature: Log Level Specification
+
+    Scenario Outline: Set the logging level by specifying the log level
+        Given a name for the logger
+        And a log level of <log_level>
+        When the get logger method is called
+        Then a logger is returned with a log level of <log_level>
+
+        Examples: Filepaths with or without the container prefix only
+            | log_level |               
+            | CRITICAL  |
+            | ERROR     |
+            | WARNING   |
+            | INFO      |
+            | DEBUG     |
+            | NOTSET    |
+
+    Scenario: The logging level is set to INFO when the log level is not specified
+        Given a name for the logger
+        And no log level specification
+        When the get logger method is called
+        Then a logger is returned with a log level of INFO
+
+    Scenario: The logging level is set to INFO when the log level is not a valid level
+        Given a name for the logger
+        And an invalid log level specification
+        When the get logger method is called
+        Then a logger is returned with a log level of INFO

--- a/krausening-python/tests/features/steps/logging_steps.py
+++ b/krausening-python/tests/features/steps/logging_steps.py
@@ -1,0 +1,39 @@
+from behave import given, when, then  # pylint: disable=no-name-in-module
+from krausening.logging import LogManager
+
+LOG_LEVEL_MAPPING = {
+    50: 'CRITICAL',
+    40: 'ERROR',
+    30: 'WARNING',
+    20: 'INFO',
+    10: 'DEBUG',
+    0: 'NOTSET',
+} 
+
+@given('a name for the logger')
+def step_impl(context):
+    context.name = 'test_logger'
+
+@given('a log level of {log_level}')
+def step_impl(context, log_level):
+    context.log_level = log_level
+
+@given('no log level specification')
+def step_impl(context):
+    context.log_level = None
+
+@given('an invalid log level specification')
+def step_impl(context):
+    context.log_level = 'WARNIG'
+
+@when('the get logger method is called')
+def step_impl(context):
+    if context.log_level:
+        context.logger = LogManager.get_instance().get_logger(context.name, context.log_level)
+    else:
+        context.logger = LogManager.get_instance().get_logger(context.name)
+
+@then('a logger is returned with a log level of {log_level}')
+def step_impl(context, log_level):
+    assigned_log_level = LOG_LEVEL_MAPPING[context.logger.level]
+    assert assigned_log_level == log_level, f'The specified log level ({log_level}) does not match the assigned log level ({assigned_log_level}).'


### PR DESCRIPTION
There are two commits included in this PR. One commit shows the changes related to the Python minimum version change and the other commit shows the changes related to the added ability to specify the Python logging level. 